### PR TITLE
fix(ci): Disable build provenance and set type=registry instead of type=docker to build an image that work on Ubuntu 16

### DIFF
--- a/.github/workflows/oci-master.yml
+++ b/.github/workflows/oci-master.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to DockerHub
+      - name: Log in to Docker Hub
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -31,5 +31,6 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: scalingo/sc-docker-cleaner:${{ github.ref_name }}
-          # For compat with old docker versions
-          outputs: type=docker,oci-mediatypes=false
+          # For compat with old Docker versions
+          provenance: false
+          outputs: type=registry,oci-mediatypes=false

--- a/.github/workflows/oci-release-tag.yml
+++ b/.github/workflows/oci-release-tag.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to DockerHub
+      - name: Log in to Docker Hub
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -35,6 +35,9 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: scalingo/sc-docker-cleaner:latest
+          # For compat with old Docker versions
+          provenance: false
+          outputs: type=docker,oci-mediatypes=false
 
       - name: "Build and push Docker image - release tag"
         uses: docker/build-push-action@v7
@@ -43,5 +46,6 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: scalingo/sc-docker-cleaner:${{ steps.vars.outputs.tag }}
-          # For compat with old docker versions
+          # For compat with old Docker versions
+          provenance: false
           outputs: type=docker,oci-mediatypes=false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## To Be Released
 
+* Disable Docker build provenance and use registry output for compatibility with old Docker versions (needed to work properly on Ubuntu 16).
+
 ## v1.0.1
 
 * chore(deps): various updates


### PR DESCRIPTION
Fix #59 and https://github.com/Scalingo/appsdeck-kitchen/issues/3706